### PR TITLE
Add flashcards to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,5 +17,46 @@
         <a class="btn" href="secant_cosecant.html">Secant &amp; Cosecant</a>
         <a class="btn" href="about.html">About Trigonometry</a>
     </main>
+
+    <section class="flashcards">
+        <div class="flashcard">
+            <p>True or False: The cosine of 0° is 1.</p>
+            <button onclick="toggleAnswer(this)">Show Answer</button>
+            <p class="answer">True</p>
+        </div>
+        <div class="flashcard">
+            <p>Which value equals sin(90°)?</p>
+            <ol type="A">
+                <li>-1</li>
+                <li>0</li>
+                <li>1</li>
+            </ol>
+            <button onclick="toggleAnswer(this)">Show Answer</button>
+            <p class="answer">C. 1</p>
+        </div>
+        <div class="flashcard">
+            <p>What is the reciprocal of sine called?</p>
+            <ol type="A">
+                <li>Secant</li>
+                <li>Cosecant</li>
+                <li>Tangent</li>
+            </ol>
+            <button onclick="toggleAnswer(this)">Show Answer</button>
+            <p class="answer">B. Cosecant</p>
+        </div>
+    </section>
+
+    <script>
+        function toggleAnswer(btn) {
+            const ans = btn.nextElementSibling;
+            if (ans.style.display === 'block') {
+                ans.style.display = 'none';
+                btn.textContent = 'Show Answer';
+            } else {
+                ans.style.display = 'block';
+                btn.textContent = 'Hide Answer';
+            }
+        }
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -42,3 +42,29 @@ body {
     background: rgba(0,0,0,0.4);
     transform: scale(1.05);
 }
+
+.flashcards {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 2rem;
+    max-width: 600px;
+    width: 100%;
+}
+
+.flashcard {
+    background: white;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.flashcard button {
+    margin-top: 0.5rem;
+}
+
+.flashcard .answer {
+    display: none;
+    font-weight: bold;
+    margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add interactive flashcard section with three sample questions
- add basic CSS styles for flashcards

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68469d0cbca883298a75f7e631dea45b